### PR TITLE
glt - Add UCSBOrganization database

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
@@ -1,0 +1,22 @@
+package edu.ucsb.cs156.example.entities;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsborganization")
+public class UCSBOrganization {
+  @Id
+  private String orgCode;
+  private String orgTranslationShort;
+  private String orgTranslation;
+  private boolean inactive;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+
+import org.springframework.beans.propertyeditors.StringArrayPropertyEditor;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, String> {
+}


### PR DESCRIPTION
In this PR we add a database to the Spring backend capable of storing UCSB Organizations.  This PR adds the required Entity and Repository classes.

Closes #25 