### PR TITLE
glt - UCSB Organization get by id

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.validation.Valid;
 
 
-@Api(description = "UCSBOrganization")
+@Api(description = "Information about UCSB organizations")
 @RequestMapping("/api/UCSBOrganization")
 @RestController
 @Slf4j
@@ -31,7 +31,7 @@ public class UCSBOrganizationController extends ApiController {
     @Autowired
     UCSBOrganizationRepository ucsbOrganizationRepository;
 
-    @ApiOperation(value = "List all ucsb organizations")
+    @ApiOperation(value = "List all UCSB organizations")
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/all")
     public Iterable<UCSBOrganization> allOrganizations() {
@@ -43,10 +43,10 @@ public class UCSBOrganizationController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
     public UCSBOrganization postOrganizations(
-        @ApiParam("orgCode") @RequestParam String orgCode,
-        @ApiParam("orgTranslationShort") @RequestParam String orgTranslationShort,
-        @ApiParam("orgTranslation") @RequestParam String orgTranslation,
-        @ApiParam("inactive") @RequestParam boolean inactive
+        @ApiParam("organization code, e.g. SKY") @RequestParam String orgCode,
+        @ApiParam("organization translation (short), e.g. Skydiving Club") @RequestParam String orgTranslationShort,
+        @ApiParam("organization translation, e.g. Skydiving Club at UCSB") @RequestParam String orgTranslation,
+        @ApiParam("true (resp. false) for inactive (resp. inactive) organizations") @RequestParam boolean inactive
         )
         {
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -60,4 +60,16 @@ public class UCSBOrganizationController extends ApiController {
 
         return organization;
     }
+
+    @ApiOperation(value = "Get a single organization")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBOrganization getById(
+            @ApiParam("unique organization code, e.g. SKY") @RequestParam String id) {
+        UCSBOrganization org = ucsbOrganizationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, id));
+
+        return org;
+    }
+
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,0 +1,63 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+
+@Api(description = "UCSBOrganization")
+@RequestMapping("/api/UCSBOrganization")
+@RestController
+@Slf4j
+public class UCSBOrganizationController extends ApiController {
+
+    @Autowired
+    UCSBOrganizationRepository ucsbOrganizationRepository;
+
+    @ApiOperation(value = "List all ucsb organizations")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBOrganization> allOrganizations() {
+        Iterable<UCSBOrganization> organization = ucsbOrganizationRepository.findAll();
+        return organization;
+    }
+
+    @ApiOperation(value = "Create a new organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBOrganization postOrganizations(
+        @ApiParam("orgCode") @RequestParam String orgCode,
+        @ApiParam("orgTranslationShort") @RequestParam String orgTranslationShort,
+        @ApiParam("orgTranslation") @RequestParam String orgTranslation,
+        @ApiParam("inactive") @RequestParam boolean inactive
+        )
+        {
+
+        UCSBOrganization organization = new UCSBOrganization();
+        organization.setOrgCode(orgCode);
+        organization.setOrgTranslationShort(orgTranslationShort);
+        organization.setOrgTranslation(orgTranslation);
+        organization.setInactive(inactive);
+
+        UCSBOrganization savedOrganization = ucsbOrganizationRepository.save(organization);
+
+        return organization;
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -55,6 +55,13 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                                 .andExpect(status().is(200)); // logged
         }
 
+    @Test
+    public void logged_out_users_cannot_get_by_id() throws Exception {
+	mockMvc.perform(get("/api/UCSBOrganization?id=SKY"))
+	    .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+
         // Authorization tests for /api/UCSBOrganization/post
         // (Perhaps should also have these for put and delete)
 
@@ -71,6 +78,56 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                                 .andExpect(status().is(403)); // only admins can post
         }
 
+        // Tests with mocks for database actions
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+
+	    UCSBOrganization tabletop = UCSBOrganization.builder()
+		.orgCode("TTGC")
+		.orgTranslationShort("Tabletop Club")
+		.orgTranslation("Tabletop Gaming Club")
+		.inactive(false)
+		.build();
+
+                when(ucsbOrganizationRepository.findById(eq("TTGC"))).thenReturn(Optional.of(tabletop));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/UCSBOrganization?id=TTGC"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findById(eq("TTGC"));
+                String expectedJson = mapper.writeValueAsString(tabletop);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(ucsbOrganizationRepository.findById(eq("TTGC"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/UCSBOrganization?id=TTGC"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findById(eq("TTGC"));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("UCSBOrganization with id TTGC not found", json.get("message"));
+        }
+
+    
         @WithMockUser(roles = { "USER" })
         @Test
         public void logged_in_user_can_get_all_organizations() throws Exception {

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -1,0 +1,137 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBOrganizationController.class)
+@Import(TestConfig.class)
+public class UCSBOrganizationControllerTests extends ControllerTestCase {
+
+        @MockBean
+        UCSBOrganizationRepository ucsbOrganizationRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Authorization tests for /api/UCSBOrganization/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/UCSBOrganization/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/UCSBOrganization/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        // Authorization tests for /api/UCSBOrganization/post
+        // (Perhaps should also have these for put and delete)
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/UCSBOrganization/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/UCSBOrganization/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_organizations() throws Exception {
+
+                // arrange
+
+                UCSBOrganization sky = UCSBOrganization.builder()
+		    .orgCode("SKY")
+		    .orgTranslationShort("Skydiving Club")
+		    .orgTranslation("Skydiving Club at UCSB")
+		    .inactive(false)
+		    .build();
+
+		UCSBOrganization tabletop = UCSBOrganization.builder()
+		    .orgCode("TTGC")
+		    .orgTranslationShort("Tabletop Club")
+		    .orgTranslation("Tabletop Gaming Club")
+		    .inactive(false)
+		    .build();
+
+                ArrayList<UCSBOrganization> expectedOrg = new ArrayList<>();
+                expectedOrg.addAll(Arrays.asList(sky, tabletop));
+
+                when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrg);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/UCSBOrganization/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedOrg);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_organization() throws Exception {
+                // arrange
+
+                UCSBOrganization sky = UCSBOrganization.builder()
+		    .orgCode("SKY")
+		    .orgTranslationShort("Skydiving Club")
+		    .orgTranslation("Skydiving Club at UCSB")
+		    .inactive(true)
+		    .build();
+
+                when(ucsbOrganizationRepository.save(eq(sky))).thenReturn(sky);
+
+                // act
+                MvcResult response = mockMvc.perform(
+						     post("/api/UCSBOrganization/post?orgCode=SKY&orgTranslationShort=Skydiving Club&orgTranslation=Skydiving Club at UCSB&inactive=true")
+						     .with(csrf()))
+		    .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).save(sky);
+                String expectedJson = mapper.writeValueAsString(sky);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+}


### PR DESCRIPTION
In this PR we add the endpoint `/api/UCSBOrganization?id=` to find organizations by id. The code has 100% coverage and kill rate.

Closes #23 

MERGE AFTER #44